### PR TITLE
Fix wage retrieval calls

### DIFF
--- a/LifeMeter-v1.2.0 (1)/LifeMeter/Modules/TransactionLogger/Sources/LogTransactionIntent.swift
+++ b/LifeMeter-v1.2.0 (1)/LifeMeter/Modules/TransactionLogger/Sources/LogTransactionIntent.swift
@@ -1,5 +1,6 @@
 import Foundation
 import AppIntents
+import HistoryStore
 
 // MARK: - Log Transaction Intent
 @available(iOS 17.0, *)
@@ -60,7 +61,7 @@ public struct LogTransactionIntent: AppIntent {
             
             // Return success result with summary
             let formattedPrice = CurrencyUtilities.formatPrice(amount, currency: currency)
-            let wage = KeychainManager.shared.getWage()
+            let wage = try? HardenedKeychainManager.shared.loadWage()
             let minutes = ConversionEngine.convertToWorkTime(price: amount, hourlyWage: wage?.amount ?? 0)
             let formattedTime = ConversionEngine.formatWorkTime(minutes)
             

--- a/LifeMeter-v1.2.0 (1)/LifeMeter/Modules/TransactionLogger/Sources/TransactionLogger.swift
+++ b/LifeMeter-v1.2.0 (1)/LifeMeter/Modules/TransactionLogger/Sources/TransactionLogger.swift
@@ -25,7 +25,7 @@ public class TransactionLogger: ObservableObject {
     @MainActor
     public func handle(_ transaction: Transaction) async throws {
         // Get current wage from Keychain
-        guard let wage = KeychainManager.shared.getWage() else {
+        guard let wage = try HardenedKeychainManager.shared.loadWage() else {
             throw TransactionLoggerError.noWageConfigured
         }
         


### PR DESCRIPTION
## Summary
- update `LogTransactionIntent` to import `HistoryStore`
- replace deprecated `getWage()` with `loadWage()` in transaction modules

## Testing
- `swift test` *(fails: invalid custom path 'Modules/PriceCapture/Tests')*

------
https://chatgpt.com/codex/tasks/task_e_688225e6d7b08330b153568f17a93108