### PR TITLE
Fix HistoryStore test context

### DIFF
--- a/LifeMeter-v1.2.0 (1)/LifeMeter/Modules/HistoryStore/Tests/FileBasedAttachmentTests.swift
+++ b/LifeMeter-v1.2.0 (1)/LifeMeter/Modules/HistoryStore/Tests/FileBasedAttachmentTests.swift
@@ -501,14 +501,80 @@ final class HistoryEntryAttachmentTests: XCTestCase {
     // MARK: - Helper Methods
     
     private func createTestContext() -> NSManagedObjectContext {
-        let model = NSManagedObjectModel()
+        // Load the actual Core Data model bundled with HistoryStore
+        let historyBundle = Bundle(for: DataController.self)
+        guard let model = NSManagedObjectModel.mergedModel(from: [historyBundle]) else {
+            fatalError("Failed to load LifeMeterModel")
+        }
+
+        // Ensure HistoryEntry entity exists
+        if model.entitiesByName["HistoryEntry"] == nil {
+            let entity = NSEntityDescription()
+            entity.name = "HistoryEntry"
+            entity.managedObjectClassName = "HistoryEntry"
+
+            // Attributes
+            let calculationId = NSAttributeDescription()
+            calculationId.name = "calculationId"
+            calculationId.attributeType = .UUIDAttributeType
+            calculationId.isOptional = true
+
+            let timestamp = NSAttributeDescription()
+            timestamp.name = "timestamp"
+            timestamp.attributeType = .dateAttributeType
+            timestamp.isOptional = false
+
+            let price = NSAttributeDescription()
+            price.name = "price"
+            price.attributeType = .doubleAttributeType
+            price.defaultValue = 0.0
+
+            let currency = NSAttributeDescription()
+            currency.name = "currency"
+            currency.attributeType = .stringAttributeType
+            currency.isOptional = false
+
+            let workMinutes = NSAttributeDescription()
+            workMinutes.name = "workMinutes"
+            workMinutes.attributeType = .doubleAttributeType
+            workMinutes.defaultValue = 0.0
+
+            let source = NSAttributeDescription()
+            source.name = "source"
+            source.attributeType = .stringAttributeType
+            source.isOptional = true
+
+            let photoData = NSAttributeDescription()
+            photoData.name = "photoData"
+            photoData.attributeType = .binaryDataAttributeType
+            photoData.isOptional = true
+            photoData.allowsExternalBinaryDataStorage = true
+
+            let attachmentURL = NSAttributeDescription()
+            attachmentURL.name = "attachmentURL"
+            attachmentURL.attributeType = .URIAttributeType
+            attachmentURL.isOptional = true
+
+            entity.properties = [
+                calculationId,
+                timestamp,
+                price,
+                currency,
+                workMinutes,
+                source,
+                photoData,
+                attachmentURL
+            ]
+
+            model.entities.append(entity)
+        }
+
         let coordinator = NSPersistentStoreCoordinator(managedObjectModel: model)
-        
         try! coordinator.addPersistentStore(ofType: NSInMemoryStoreType, configurationName: nil, at: nil, options: nil)
-        
+
         let context = NSManagedObjectContext(concurrencyType: .mainQueueConcurrencyType)
         context.persistentStoreCoordinator = coordinator
-        
+
         return context
     }
     
@@ -618,14 +684,80 @@ final class AttachmentMigrationTests: XCTestCase {
     // MARK: - Helper Methods
     
     private func createTestContext() -> NSManagedObjectContext {
-        let model = NSManagedObjectModel()
+        // Load the actual Core Data model bundled with HistoryStore
+        let historyBundle = Bundle(for: DataController.self)
+        guard let model = NSManagedObjectModel.mergedModel(from: [historyBundle]) else {
+            fatalError("Failed to load LifeMeterModel")
+        }
+
+        // Ensure HistoryEntry entity exists
+        if model.entitiesByName["HistoryEntry"] == nil {
+            let entity = NSEntityDescription()
+            entity.name = "HistoryEntry"
+            entity.managedObjectClassName = "HistoryEntry"
+
+            // Attributes
+            let calculationId = NSAttributeDescription()
+            calculationId.name = "calculationId"
+            calculationId.attributeType = .UUIDAttributeType
+            calculationId.isOptional = true
+
+            let timestamp = NSAttributeDescription()
+            timestamp.name = "timestamp"
+            timestamp.attributeType = .dateAttributeType
+            timestamp.isOptional = false
+
+            let price = NSAttributeDescription()
+            price.name = "price"
+            price.attributeType = .doubleAttributeType
+            price.defaultValue = 0.0
+
+            let currency = NSAttributeDescription()
+            currency.name = "currency"
+            currency.attributeType = .stringAttributeType
+            currency.isOptional = false
+
+            let workMinutes = NSAttributeDescription()
+            workMinutes.name = "workMinutes"
+            workMinutes.attributeType = .doubleAttributeType
+            workMinutes.defaultValue = 0.0
+
+            let source = NSAttributeDescription()
+            source.name = "source"
+            source.attributeType = .stringAttributeType
+            source.isOptional = true
+
+            let photoData = NSAttributeDescription()
+            photoData.name = "photoData"
+            photoData.attributeType = .binaryDataAttributeType
+            photoData.isOptional = true
+            photoData.allowsExternalBinaryDataStorage = true
+
+            let attachmentURL = NSAttributeDescription()
+            attachmentURL.name = "attachmentURL"
+            attachmentURL.attributeType = .URIAttributeType
+            attachmentURL.isOptional = true
+
+            entity.properties = [
+                calculationId,
+                timestamp,
+                price,
+                currency,
+                workMinutes,
+                source,
+                photoData,
+                attachmentURL
+            ]
+
+            model.entities.append(entity)
+        }
+
         let coordinator = NSPersistentStoreCoordinator(managedObjectModel: model)
-        
         try! coordinator.addPersistentStore(ofType: NSInMemoryStoreType, configurationName: nil, at: nil, options: nil)
-        
+
         let context = NSManagedObjectContext(concurrencyType: .mainQueueConcurrencyType)
         context.persistentStoreCoordinator = coordinator
-        
+
         return context
     }
     


### PR DESCRIPTION
## Summary
- load Core Data model from HistoryStore in file-based attachment tests
- create HistoryEntry entity if missing when building in-memory context for tests

## Testing
- `swift test -l` *(fails: no such module 'Combine')*

------
https://chatgpt.com/codex/tasks/task_e_68823cf55d7c8330b03373d601409b7b