### PR TITLE
Fix Keychain save invocation

### DIFF
--- a/LifeMeter-v1.2.0 (1)/LifeMeter/Modules/WageOnboarding/Sources/WageEntryView.swift
+++ b/LifeMeter-v1.2.0 (1)/LifeMeter/Modules/WageOnboarding/Sources/WageEntryView.swift
@@ -321,7 +321,7 @@ public class WageEntryViewModel: ObservableObject {
                     period: selectedPeriod
                 )
                 
-                try await KeychainManager.shared.saveWage(wage)
+                try KeychainManager.shared.saveWage(wage)
                 
                 await MainActor.run {
                     isLoading = false


### PR DESCRIPTION
## Summary
- drop misplaced await call when saving a Wage

## Testing
- `swift test` *(fails: no such module 'Combine')*

------
https://chatgpt.com/codex/tasks/task_e_68823cf664ac83308bbe60fa1cfff127