### PR TITLE
Fix convert button state logic

### DIFF
--- a/LifeMeter-v1.2.0 (1)/LifeMeter/Modules/WageOnboarding/Sources/WageEntryView.swift
+++ b/LifeMeter-v1.2.0 (1)/LifeMeter/Modules/WageOnboarding/Sources/WageEntryView.swift
@@ -249,8 +249,10 @@ public class WageEntryViewModel: ObservableObject {
     }
     
     var isConvertButtonEnabled: Bool {
-        case .valid = wageValidationState
-        return !isLoading
+        if case .valid = wageValidationState {
+            return !isLoading
+        }
+        return false
     }
     
     // MARK: - Initialization


### PR DESCRIPTION
## Summary
- adjust `isConvertButtonEnabled` logic in `WageEntryView` to check loading state

## Testing
- `swift test` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_68823cf7bc10833086c1cdc3fdf1c624