### PR TITLE
Fix TransactionLoggerTests setup/teardown

### DIFF
--- a/LifeMeter-v1.2.0 (1)/LifeMeter/Modules/TransactionLogger/Tests/TransactionLoggerTests.swift
+++ b/LifeMeter-v1.2.0 (1)/LifeMeter/Modules/TransactionLogger/Tests/TransactionLoggerTests.swift
@@ -26,12 +26,12 @@ final class TransactionLoggerTests: XCTestCase {
         
         // Setup test wage in Keychain
         let testWage = Wage(amount: 30.0, currency: "EUR", period: .hourly)
-        KeychainManager.shared.saveWage(testWage)
+        try KeychainManager.shared.saveWage(testWage)
     }
     
     override func tearDownWithError() throws {
         // Clean up Keychain
-        KeychainManager.shared.deleteWage()
+        try KeychainManager.shared.deleteWage()
         
         transactionLogger = nil
         mockHistoryStore = nil


### PR DESCRIPTION
## Summary
- fix missing `try` calls for wage save/delete in TransactionLoggerTests

## Testing
- `swift build` *(fails: no such module 'SwiftUI' or 'Combine')*

------
https://chatgpt.com/codex/tasks/task_e_68823cf8dae08330be2379e75fce4d66