### PR TITLE
fix: add safe-fallback for Core-Data migration failures

### DIFF
--- a/App/LifeMeter/FatalMigrationErrorView.swift
+++ b/App/LifeMeter/FatalMigrationErrorView.swift
@@ -1,0 +1,31 @@
+import SwiftUI
+
+@available(iOS 15.0, *)
+struct FatalMigrationErrorView: View {
+    let error: Error
+
+    var body: some View {
+        VStack(spacing: 24) {
+            Spacer()
+            Image(systemName: "exclamationmark.triangle.fill")
+                .font(.system(size: 64))
+                .foregroundColor(.red)
+
+            Text("Data Migration Failed")
+                .font(.title)
+                .fontWeight(.bold)
+
+            Text("LifeMeter encountered an issue loading your data. Please reinstall the app or contact support.")
+                .multilineTextAlignment(.center)
+                .foregroundColor(.secondary)
+
+            Text(error.localizedDescription)
+                .font(.footnote)
+                .foregroundColor(.secondary)
+                .multilineTextAlignment(.center)
+            Spacer()
+        }
+        .padding()
+    }
+}
+

--- a/App/LifeMeter/LifeMeterApp.swift
+++ b/App/LifeMeter/LifeMeterApp.swift
@@ -14,12 +14,16 @@ struct LifeMeterApp: App {
     // MARK: - App Body
     var body: some Scene {
         WindowGroup {
-            MainAppView()
-                .environment(\.managedObjectContext, dataController.container.viewContext)
-                .environmentObject(currencyStore)
-                .onAppear {
-                    setupApp()
-                }
+            if let error = dataController.migrationError {
+                FatalMigrationErrorView(error: error)
+            } else {
+                MainAppView()
+                    .environment(\.managedObjectContext, dataController.container.viewContext)
+                    .environmentObject(currencyStore)
+                    .onAppear {
+                        setupApp()
+                    }
+            }
         }
     }
     

--- a/Modules/HistoryStore/Sources/DataModel.swift
+++ b/Modules/HistoryStore/Sources/DataModel.swift
@@ -1,13 +1,15 @@
 import Foundation
 import CoreData
 import CloudKit
+import os.log
 
 // MARK: - Core Data Stack
 @available(iOS 15.0, *)
 public class DataController: ObservableObject {
     public static let shared = DataController()
-    
+
     public let container: NSPersistentCloudKitContainer
+    @Published public var migrationError: Error?
     
     private init() {
         container = NSPersistentCloudKitContainer(name: "LifeMeterModel")
@@ -23,14 +25,49 @@ public class DataController: ObservableObject {
             containerIdentifier: "iCloud.com.lifemeter.app"
         )
         
-        container.loadPersistentStores { _, error in
-            if let error = error {
-                print("Core Data failed to load: \(error.localizedDescription)")
-            }
+        do {
+            try loadStores(description: description)
+        } catch {
+            migrationError = error
         }
-        
+
         container.viewContext.automaticallyMergesChangesFromParent = true
         container.viewContext.mergePolicy = NSMergeByPropertyObjectTrumpMergePolicy
+    }
+
+    // MARK: - Persistent Store Loading
+    private func loadStores(description: NSPersistentStoreDescription) throws {
+        var loadError: Error?
+        let group = DispatchGroup()
+        group.enter()
+        container.loadPersistentStores { _, error in
+            loadError = error
+            group.leave()
+        }
+        group.wait()
+
+        if let error = loadError {
+            moveCorruptedStore(originalURL: description.url)
+            os_log(.fault, "Failed to load persistent store: %{public}@", error.localizedDescription)
+            throw error
+        }
+    }
+
+    private func moveCorruptedStore(originalURL: URL?) {
+        guard let originalURL else { return }
+        let fileManager = FileManager.default
+        let supportDir = fileManager.homeDirectoryForCurrentUser
+            .appendingPathComponent("Library/Application Support/LifeMeter/Corrupted", isDirectory: true)
+        do {
+            try fileManager.createDirectory(at: supportDir, withIntermediateDirectories: true)
+            let destination = supportDir.appendingPathComponent(originalURL.lastPathComponent)
+            if fileManager.fileExists(atPath: destination.path) {
+                try fileManager.removeItem(at: destination)
+            }
+            try fileManager.moveItem(at: originalURL, to: destination)
+        } catch {
+            os_log(.fault, "Failed to move corrupted store: %{public}@", error.localizedDescription)
+        }
     }
     
     public func save() {


### PR DESCRIPTION
## Summary
- handle persistent store load errors in `DataController`
- move corrupted data stores to a Corrupted folder
- show `FatalMigrationErrorView` when migration fails

## Testing
- `swift build` *(fails: no such module 'Combine')*

------
https://chatgpt.com/codex/tasks/task_e_688b687d42008330bd534d85bce01e2c