### PR TITLE
ci: add swift package tests

### DIFF
--- a/CI/github-actions.yml
+++ b/CI/github-actions.yml
@@ -290,3 +290,15 @@ jobs:
           -testPlan WidgetSnapshotTests \
           CODE_SIGNING_ALLOWED=NO
 
+  spm-tests:
+    name: Swift Package Tests
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-14]
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+    - name: Swift Package Tests (macOS)
+      run: swift test --parallel
+

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -1,0 +1,2 @@
+import XCTest
+XCTMain([])


### PR DESCRIPTION
## Summary
- add CI job to run `swift test`
- add stub `LinuxMain.swift` for XCTest entrypoint

## Testing
- `swift test --parallel` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_688bd453fca08330a92167e0a1d23733