### PR TITLE
Add tests for RateManager and CurrencyStore

### DIFF
--- a/Modules/CalcCore/Sources/CurrencyManaging.swift
+++ b/Modules/CalcCore/Sources/CurrencyManaging.swift
@@ -1,0 +1,13 @@
+import Combine
+import Foundation
+
+public protocol CurrencyManaging: Actor {
+    var selectedCurrency: CurrencyCode { get }
+    var selectedCurrencyPublisher: Published<CurrencyCode>.Publisher { get }
+    func setCurrency(_ currencyCode: CurrencyCode)
+}
+
+extension CurrencyManager: CurrencyManaging {
+    public var selectedCurrencyPublisher: Published<CurrencyCode>.Publisher { $selectedCurrency }
+}
+

--- a/Modules/CalcCore/Sources/CurrencyStore.swift
+++ b/Modules/CalcCore/Sources/CurrencyStore.swift
@@ -4,9 +4,9 @@ import Foundation
 @MainActor
 public final class CurrencyStore: ObservableObject {
     @Published public private(set) var selected: CurrencyCode = "USD"
-    private let manager: CurrencyManager
+    private let manager: any CurrencyManaging
 
-    public init(manager: CurrencyManager = .shared) {
+    public init(manager: any CurrencyManaging = CurrencyManager.shared) {
         self.manager = manager
         Task { await observe() }
     }
@@ -16,8 +16,9 @@ public final class CurrencyStore: ObservableObject {
     }
 
     private func observe() async {
-        for await value in await manager.$selectedCurrency.values {
+        for await value in await manager.selectedCurrencyPublisher.values {
             selected = value
         }
     }
 }
+

--- a/Modules/ExchangeRates/Sources/ExchangeRateManager.swift
+++ b/Modules/ExchangeRates/Sources/ExchangeRateManager.swift
@@ -1,13 +1,19 @@
 import Foundation
 
 public actor ExchangeRateManager {
-    private let fetcher = RateFetcher()
-    private let cache = RateCache()
+    private let fetcher: any RateFetching
+    private let cache: any RateCaching
 
-    public init() {}
+    public init(
+        fetcher: any RateFetching = RateFetcher(),
+        cache: any RateCaching = RateCache()
+    ) {
+        self.fetcher = fetcher
+        self.cache = cache
+    }
 
     public func latest(base: CurrencyCode) async throws -> RatesResponse {
-        if let cached = cache.load(), !cached.isExpired {
+        if let cached = await cache.load(), !cached.isExpired {
             return cached
         }
         let fresh = try await fetcher.fetchLatest(base: base)
@@ -15,3 +21,4 @@ public actor ExchangeRateManager {
         return fresh
     }
 }
+

--- a/Modules/ExchangeRates/Sources/ExchangeRates/RateCache.swift
+++ b/Modules/ExchangeRates/Sources/ExchangeRates/RateCache.swift
@@ -8,7 +8,7 @@ public actor RateCache: RateCaching {
 
     public init() {}
 
-    public func load() -> RatesResponse? {
+public func load() async -> RatesResponse? {
         payload ?? readFromDisk()
     }
 

--- a/Modules/ExchangeRates/Sources/ExchangeRates/RateCache.swift
+++ b/Modules/ExchangeRates/Sources/ExchangeRates/RateCache.swift
@@ -1,10 +1,12 @@
 import Foundation
 
-public actor RateCache {
+public actor RateCache: RateCaching {
     private var payload: RatesResponse?
     private let url: URL = FileManager.default
         .urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
         .appendingPathComponent("ExchangeRates/rates.json")
+
+    public init() {}
 
     public func load() -> RatesResponse? {
         payload ?? readFromDisk()
@@ -27,3 +29,4 @@ public actor RateCache {
         try data.write(to: url)
     }
 }
+

--- a/Modules/ExchangeRates/Sources/ExchangeRates/RateFetcher.swift
+++ b/Modules/ExchangeRates/Sources/ExchangeRates/RateFetcher.swift
@@ -7,8 +7,10 @@ public actor RateFetcher: RateFetching {
     public init() {}
 
     public func fetchLatest(base: CurrencyCode) async throws -> RatesResponse {
-        let url = URL(string: "https://api.exchangerate.host/latest?base=\(base)")!
-        let (data, _) = try await session.data(from: url)
+guard let url = URL(string: "https://api.exchangerate.host/latest?base=\(base)") else {
+    throw URLError(.badURL)
+}
+let (data, _) = try await session.data(from: url)
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .formatted(Self.dateFormatter)
         return try decoder.decode(RatesResponse.self, from: data)

--- a/Modules/ExchangeRates/Sources/ExchangeRates/RateFetcher.swift
+++ b/Modules/ExchangeRates/Sources/ExchangeRates/RateFetcher.swift
@@ -1,10 +1,12 @@
 // swiftlint:disable force_unwrapping
 import Foundation
 
-public actor RateFetcher {
+public actor RateFetcher: RateFetching {
     private let session: URLSession = .shared
 
-    func fetchLatest(base: CurrencyCode) async throws -> RatesResponse {
+    public init() {}
+
+    public func fetchLatest(base: CurrencyCode) async throws -> RatesResponse {
         let url = URL(string: "https://api.exchangerate.host/latest?base=\(base)")!
         let (data, _) = try await session.data(from: url)
         let decoder = JSONDecoder()
@@ -19,3 +21,4 @@ public actor RateFetcher {
         return formatter
     }()
 }
+

--- a/Modules/ExchangeRates/Sources/ExchangeRates/RateProtocols.swift
+++ b/Modules/ExchangeRates/Sources/ExchangeRates/RateProtocols.swift
@@ -5,7 +5,7 @@ public protocol RateFetching: Sendable {
 }
 
 public protocol RateCaching: Sendable {
-    func load() -> RatesResponse?
+func load() async -> RatesResponse?
     func save(_ response: RatesResponse) async throws
 }
 

--- a/Modules/ExchangeRates/Sources/ExchangeRates/RateProtocols.swift
+++ b/Modules/ExchangeRates/Sources/ExchangeRates/RateProtocols.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+public protocol RateFetching: Sendable {
+    func fetchLatest(base: CurrencyCode) async throws -> RatesResponse
+}
+
+public protocol RateCaching: Sendable {
+    func load() -> RatesResponse?
+    func save(_ response: RatesResponse) async throws
+}
+

--- a/Package.swift
+++ b/Package.swift
@@ -96,7 +96,12 @@ let package = Package(
         .testTarget(
             name: "ExchangeRatesTests",
             dependencies: ["ExchangeRates"],
-            path: "Modules/ExchangeRates/Tests"
+            path: "Tests/ExchangeRatesTests"
+        ),
+        .testTarget(
+            name: "CurrencyStoreTests",
+            dependencies: ["CalcCore"],
+            path: "Tests/CurrencyStoreTests"
         ),
 
         .target(
@@ -164,3 +169,4 @@ let package = Package(
         ),
     ]
 )
+

--- a/Tests/CurrencyStoreTests/CurrencyStoreTests.swift
+++ b/Tests/CurrencyStoreTests/CurrencyStoreTests.swift
@@ -24,7 +24,7 @@ final class CurrencyStoreTests: XCTestCase {
         }
 
         await store.set("GBP")
-        await waitForExpectations(timeout: 1)
+await fulfillment(of: [exp], timeout: 1)
         _ = cancellable
     }
 }

--- a/Tests/CurrencyStoreTests/CurrencyStoreTests.swift
+++ b/Tests/CurrencyStoreTests/CurrencyStoreTests.swift
@@ -1,0 +1,31 @@
+import Combine
+import XCTest
+@testable import CalcCore
+
+@MainActor
+final class CurrencyStoreTests: XCTestCase {
+    actor InMemoryCurrencyManager: CurrencyManaging {
+        @Published var selectedCurrency: CurrencyCode = "USD"
+        var selectedCurrencyPublisher: Published<CurrencyCode>.Publisher { $selectedCurrency }
+        func setCurrency(_ currencyCode: CurrencyCode) {
+            selectedCurrency = currencyCode
+        }
+    }
+
+    func test_selected_updates_on_main_thread() async throws {
+        let manager = InMemoryCurrencyManager()
+        let store = CurrencyStore(manager: manager)
+        let exp = expectation(description: "update")
+
+        let cancellable = store.$selected.dropFirst().sink { value in
+            XCTAssertTrue(Thread.isMainThread)
+            XCTAssertEqual(value, "GBP")
+            exp.fulfill()
+        }
+
+        await store.set("GBP")
+        await waitForExpectations(timeout: 1)
+        _ = cancellable
+    }
+}
+

--- a/Tests/ExchangeRatesTests/RateManagerTests.swift
+++ b/Tests/ExchangeRatesTests/RateManagerTests.swift
@@ -1,0 +1,54 @@
+import XCTest
+@testable import ExchangeRates
+
+@MainActor
+final class RateManagerTests: XCTestCase {
+    actor FakeFetcher: RateFetching {
+        var payload: RatesResponse
+        var fetchCount = 0
+        init(payload: RatesResponse) { self.payload = payload }
+        func fetchLatest(base: CurrencyCode) async throws -> RatesResponse {
+            fetchCount += 1
+            return payload
+        }
+    }
+
+    actor FakeCache: RateCaching {
+        var stored: RatesResponse?
+        init(initial: RatesResponse? = nil) { stored = initial }
+        func load() -> RatesResponse? { stored }
+        func save(_ response: RatesResponse) async throws { stored = response }
+    }
+
+    func test_cached_path_hits_without_network() async throws {
+        let today = Date()
+        let cached = RatesResponse(base: "USD", date: today, rates: ["EUR": 0.9])
+        let fetcher = FakeFetcher(payload: RatesResponse(base: "USD", date: today, rates: ["EUR": 1.1]))
+        let cache = FakeCache(initial: cached)
+        let manager = ExchangeRateManager(fetcher: fetcher, cache: cache)
+
+        let result = try await manager.latest(base: "USD")
+
+        XCTAssertEqual(result.rates["EUR"], 0.9)
+        let fetchCount = await fetcher.fetchCount
+        XCTAssertEqual(fetchCount, 0)
+    }
+
+    func test_fresh_path_when_expired() async throws {
+        let oldDate = Calendar.current.date(byAdding: .day, value: -2, to: Date())!
+        let expired = RatesResponse(base: "USD", date: oldDate, rates: ["EUR": 0.8])
+        let fresh = RatesResponse(base: "USD", date: Date(), rates: ["EUR": 0.9])
+        let fetcher = FakeFetcher(payload: fresh)
+        let cache = FakeCache(initial: expired)
+        let manager = ExchangeRateManager(fetcher: fetcher, cache: cache)
+
+        let result = try await manager.latest(base: "USD")
+
+        XCTAssertEqual(result.rates["EUR"], 0.9)
+        let fetchCount = await fetcher.fetchCount
+        XCTAssertEqual(fetchCount, 1)
+        let cached = await cache.load()
+        XCTAssertEqual(cached?.date, fresh.date)
+    }
+}
+

--- a/Tests/ExchangeRatesTests/RateManagerTests.swift
+++ b/Tests/ExchangeRatesTests/RateManagerTests.swift
@@ -16,7 +16,7 @@ final class RateManagerTests: XCTestCase {
     actor FakeCache: RateCaching {
         var stored: RatesResponse?
         init(initial: RatesResponse? = nil) { stored = initial }
-        func load() -> RatesResponse? { stored }
+func load() async -> RatesResponse? { stored }
         func save(_ response: RatesResponse) async throws { stored = response }
     }
 


### PR DESCRIPTION
## Summary
- enable dependency injection for `ExchangeRateManager`
- expose protocols `RateFetching` and `RateCaching`
- add `CurrencyManaging` protocol and update `CurrencyStore`
- add unit tests for `RateManager` and `CurrencyStore`
- register new test targets in `Package.swift`

## Testing
- `swift test -l` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_688bd8ffcb588330acb58f714f53d214