### PR TITLE
log: add %{public}/%{private} modifiers to os_log

### DIFF
--- a/Modules/AppShell/Sources/AppShellViewModels.swift
+++ b/Modules/AppShell/Sources/AppShellViewModels.swift
@@ -192,8 +192,8 @@ public class SettingsViewModel: ObservableObject {
             #if DEBUG
                 os_log(
                     .error,
-                    "Failed to load settings: %{private}@",
                     log: .appShell,
+                    "Failed to load settings: %{private}@",
                     String(describing: error)
                 )
             #endif

--- a/Modules/AppShell/Sources/AppShellViewModels.swift
+++ b/Modules/AppShell/Sources/AppShellViewModels.swift
@@ -216,8 +216,8 @@ public class SettingsViewModel: ObservableObject {
             #if DEBUG
                 os_log(
                     .error,
-                    "Failed to update settings: %{private}@",
                     log: .appShell,
+                    "Failed to update settings: %{private}@",
                     String(describing: error)
                 )
             #endif

--- a/Modules/AppShell/Sources/AppShellViewModels.swift
+++ b/Modules/AppShell/Sources/AppShellViewModels.swift
@@ -291,8 +291,8 @@ public class HistoryViewModel: ObservableObject {
             #if DEBUG
                 os_log(
                     .error,
-                    "Failed to clear calculations: %{private}@",
                     log: .appShell,
+                    "Failed to clear calculations: %{private}@",
                     String(describing: error)
                 )
             #endif

--- a/Modules/AppShell/Sources/AppShellViewModels.swift
+++ b/Modules/AppShell/Sources/AppShellViewModels.swift
@@ -160,8 +160,8 @@ public class SettingsViewModel: ObservableObject {
             #if DEBUG
                 os_log(
                     .error,
-                    "Failed to clear data: %{private}@",
                     log: .appShell,
+                    "Failed to clear data: %{private}@",
                     String(describing: error)
                 )
             #endif

--- a/Modules/AppShell/Sources/AppShellViewModels.swift
+++ b/Modules/AppShell/Sources/AppShellViewModels.swift
@@ -254,8 +254,8 @@ public class HistoryViewModel: ObservableObject {
             #if DEBUG
                 os_log(
                     .error,
-                    "Failed to load calculations: %{private}@",
                     log: .appShell,
+                    "Failed to load calculations: %{private}@",
                     String(describing: error)
                 )
             #endif

--- a/Modules/AppShell/Sources/AppShellViewModels.swift
+++ b/Modules/AppShell/Sources/AppShellViewModels.swift
@@ -158,7 +158,12 @@ public class SettingsViewModel: ObservableObject {
             DataController.shared.save()
         } catch {
             #if DEBUG
-                os_log(.error, "Failed to clear data: %{public}@", String(describing: error))
+                os_log(
+                    .error,
+                    "Failed to clear data: %{private}@",
+                    log: .appShell,
+                    String(describing: error)
+                )
             #endif
         }
     }
@@ -185,7 +190,12 @@ public class SettingsViewModel: ObservableObject {
             }
         } catch {
             #if DEBUG
-                os_log(.error, "Failed to load settings: %{public}@", String(describing: error))
+                os_log(
+                    .error,
+                    "Failed to load settings: %{private}@",
+                    log: .appShell,
+                    String(describing: error)
+                )
             #endif
         }
     }
@@ -204,7 +214,12 @@ public class SettingsViewModel: ObservableObject {
             DataController.shared.save()
         } catch {
             #if DEBUG
-                os_log(.error, "Failed to update settings: %{public}@", String(describing: error))
+                os_log(
+                    .error,
+                    "Failed to update settings: %{private}@",
+                    log: .appShell,
+                    String(describing: error)
+                )
             #endif
         }
     }
@@ -237,7 +252,12 @@ public class HistoryViewModel: ObservableObject {
             calculations = try context.fetch(request)
         } catch {
             #if DEBUG
-                os_log(.error, "Failed to load calculations: %{public}@", String(describing: error))
+                os_log(
+                    .error,
+                    "Failed to load calculations: %{private}@",
+                    log: .appShell,
+                    String(describing: error)
+                )
             #endif
             calculations = []
         }
@@ -269,7 +289,12 @@ public class HistoryViewModel: ObservableObject {
             loadCalculations()
         } catch {
             #if DEBUG
-                os_log(.error, "Failed to clear calculations: %{public}@", String(describing: error))
+                os_log(
+                    .error,
+                    "Failed to clear calculations: %{private}@",
+                    log: .appShell,
+                    String(describing: error)
+                )
             #endif
         }
     }

--- a/Modules/AppShell/Sources/BiometricAuthenticationGate.swift
+++ b/Modules/AppShell/Sources/BiometricAuthenticationGate.swift
@@ -156,11 +156,26 @@ public class BiometricAuthenticationGate: ObservableObject {
 
     private func logAuthenticationEvent(_ event: AuthenticationEvent, details: String? = nil) {
         let timestamp = ISO8601DateFormatter().string(from: Date())
-        let message = event.rawValue + (details.map { " - \($0)" } ?? "")
 
         #if DEBUG
-            os_log(.debug, "\u{1F510} Auth Event [%{public}@]: %{public}@",
-                   timestamp, message)
+            if let details {
+                os_log(
+                    .debug,
+                    "\u{1F510} Auth Event [%{private}@]: %{public}@ - %{private}@",
+                    log: .appShell,
+                    timestamp,
+                    event.rawValue,
+                    details
+                )
+            } else {
+                os_log(
+                    .debug,
+                    "\u{1F510} Auth Event [%{private}@]: %{public}@",
+                    log: .appShell,
+                    timestamp,
+                    event.rawValue
+                )
+            }
         #endif
 
         // In production, log to security audit trail

--- a/Modules/AppShell/Sources/BiometricAuthenticationGate.swift
+++ b/Modules/AppShell/Sources/BiometricAuthenticationGate.swift
@@ -161,8 +161,8 @@ public class BiometricAuthenticationGate: ObservableObject {
             if let details {
                 os_log(
                     .debug,
-                    "\u{1F510} Auth Event [%{private}@]: %{public}@ - %{private}@",
                     log: .appShell,
+                    "\u{1F510} Auth Event [%{private}@]: %{public}@ - %{private}@",
                     timestamp,
                     event.rawValue,
                     details
@@ -170,8 +170,8 @@ public class BiometricAuthenticationGate: ObservableObject {
             } else {
                 os_log(
                     .debug,
-                    "\u{1F510} Auth Event [%{private}@]: %{public}@",
                     log: .appShell,
+                    "\u{1F510} Auth Event [%{private}@]: %{public}@",
                     timestamp,
                     event.rawValue
                 )

--- a/Modules/AppShell/Sources/CombineCancellableManager.swift
+++ b/Modules/AppShell/Sources/CombineCancellableManager.swift
@@ -101,8 +101,13 @@ open class BaseViewModel: ObservableObject, CancellableStorage {
         cancellableManager.cancelAll()
 
         #if DEBUG
-            os_log(.debug, "\u{1F5D1} %{public}@ deinitialized, cancelled %{public}d subscriptions",
-                   String(describing: type(of: self)), cancellableManager.activeCancellablesCount)
+            os_log(
+                .debug,
+                "\u{1F5D1} %{public}@ deinitialized, cancelled %{public}d subscriptions",
+                log: .appShell,
+                String(describing: type(of: self)),
+                cancellableManager.activeCancellablesCount
+            )
         #endif
     }
 }
@@ -130,8 +135,13 @@ open class BaseViewController: UIViewController, CancellableStorage {
         cancellableManager.cancelAll()
 
         #if DEBUG
-            os_log(.debug, "\u{1F5D1} %{public}@ deinitialized, cancelled %{public}d subscriptions",
-                   String(describing: type(of: self)), cancellableManager.activeCancellablesCount)
+            os_log(
+                .debug,
+                "\u{1F5D1} %{public}@ deinitialized, cancelled %{public}d subscriptions",
+                log: .appShell,
+                String(describing: type(of: self)),
+                cancellableManager.activeCancellablesCount
+            )
         #endif
     }
 }
@@ -198,11 +208,26 @@ public class SubscriptionTracker {
     public func printSubscriptionReport() {
         let subscriptions = getAllActiveSubscriptions()
 
-        os_log(.info, "\u{1F4CA} Active Subscriptions Report:")
-        os_log(.info, "Total: %{public}d", totalActiveSubscriptions)
+        os_log(
+            .info,
+            "\u{1F4CA} Active Subscriptions Report:",
+            log: .appShell
+        )
+        os_log(
+            .info,
+            "Total: %{public}d",
+            log: .appShell,
+            totalActiveSubscriptions
+        )
 
         for (owner, count) in subscriptions.sorted(by: { $0.value > $1.value }) {
-            os_log(.info, "  %{public}@: %{public}d", owner, count)
+            os_log(
+                .info,
+                "  %{public}@: %{public}d",
+                log: .appShell,
+                owner,
+                count
+            )
         }
     }
 }
@@ -311,8 +336,12 @@ public class MemoryLeakDetector {
 
         #if DEBUG
             if totalSubscriptions > 50 { // Threshold for potential leak
-                os_log(.fault, "\u{26A0}\u{FE0F} Potential memory leak detected: %{public}d active subscriptions",
-                       totalSubscriptions)
+                os_log(
+                    .fault,
+                    "\u{26A0}\u{FE0F} Potential memory leak detected: %{public}d active subscriptions",
+                    log: .appShell,
+                    totalSubscriptions
+                )
                 SubscriptionTracker.shared.printSubscriptionReport()
             }
         #endif

--- a/Modules/AppShell/Sources/CombineCancellableManager.swift
+++ b/Modules/AppShell/Sources/CombineCancellableManager.swift
@@ -137,8 +137,8 @@ open class BaseViewController: UIViewController, CancellableStorage {
         #if DEBUG
             os_log(
                 .debug,
-                "\u{1F5D1} %{public}@ deinitialized, cancelled %{public}d subscriptions",
                 log: .appShell,
+                "\u{1F5D1} %{public}@ deinitialized, cancelled %{public}d subscriptions",
                 String(describing: type(of: self)),
                 cancellableManager.activeCancellablesCount
             )

--- a/Modules/AppShell/Sources/CombineCancellableManager.swift
+++ b/Modules/AppShell/Sources/CombineCancellableManager.swift
@@ -103,8 +103,8 @@ open class BaseViewModel: ObservableObject, CancellableStorage {
         #if DEBUG
             os_log(
                 .debug,
-                "\u{1F5D1} %{public}@ deinitialized, cancelled %{public}d subscriptions",
                 log: .appShell,
+                "\u{1F5D1} %{public}@ deinitialized, cancelled %{public}d subscriptions",
                 String(describing: type(of: self)),
                 cancellableManager.activeCancellablesCount
             )

--- a/Modules/AppShell/Sources/OSLog+Subsystem.swift
+++ b/Modules/AppShell/Sources/OSLog+Subsystem.swift
@@ -1,0 +1,5 @@
+import os.log
+
+extension OSLog {
+    static let appShell = OSLog(subsystem: "com.rep0mancer.lifemeter", category: "AppShell")
+}

--- a/Modules/HistoryStore/Sources/DataModel.swift
+++ b/Modules/HistoryStore/Sources/DataModel.swift
@@ -50,7 +50,11 @@ public class DataController: ObservableObject {
 
         if let error = loadError {
             moveCorruptedStore(originalURL: description.url)
-            os_log(.fault, "Failed to load persistent store: %{public}@", error.localizedDescription)
+            os_log(
+                .fault,
+                "Failed to load persistent store: %{private}@",
+                error.localizedDescription
+            )
             throw error
         }
     }
@@ -68,7 +72,11 @@ public class DataController: ObservableObject {
             }
             try fileManager.moveItem(at: originalURL, to: destination)
         } catch {
-            os_log(.fault, "Failed to move corrupted store: %{public}@", error.localizedDescription)
+            os_log(
+                .fault,
+                "Failed to move corrupted store: %{private}@",
+                error.localizedDescription
+            )
         }
     }
 
@@ -80,7 +88,11 @@ public class DataController: ObservableObject {
                 try context.save()
             } catch {
                 #if DEBUG
-                    os_log(.error, "Failed to save context: %{public}@", String(describing: error))
+                    os_log(
+                        .error,
+                        "Failed to save context: %{private}@",
+                        String(describing: error)
+                    )
                 #endif
             }
         }

--- a/Modules/HistoryStore/Sources/FileBasedAttachmentManager.swift
+++ b/Modules/HistoryStore/Sources/FileBasedAttachmentManager.swift
@@ -152,8 +152,12 @@ public class FileBasedAttachmentManager {
                 entry.photoData = nil // Remove binary data
             } catch {
                 #if DEBUG
-                    os_log(.error, "Failed to migrate attachment for entry %{public}@: %{public}@",
-                           calculationId.uuidString, String(describing: error))
+                    os_log(
+                        .error,
+                        "Failed to migrate attachment for entry %{private}@: %{private}@",
+                        calculationId.uuidString,
+                        String(describing: error)
+                    )
                 #endif
             }
         }
@@ -169,8 +173,11 @@ public class FileBasedAttachmentManager {
                 try fileManager.createDirectory(at: attachmentsDirectory, withIntermediateDirectories: true)
             } catch {
                 #if DEBUG
-                    os_log(.error, "Failed to create attachments directory: %{public}@",
-                           String(describing: error))
+                    os_log(
+                        .error,
+                        "Failed to create attachments directory: %{private}@",
+                        String(describing: error)
+                    )
                 #endif
             }
         }
@@ -274,7 +281,10 @@ public class AttachmentMigrationHelper {
     /// Perform migration from binary data to file-based storage
     public static func performMigration(context: NSManagedObjectContext) throws {
         #if DEBUG
-            os_log(.info, "Starting attachment migration...")
+            os_log(
+                .info,
+                "Starting attachment migration..."
+            )
         #endif
 
         let startTime = Date()
@@ -284,12 +294,20 @@ public class AttachmentMigrationHelper {
 
             let duration = Date().timeIntervalSince(startTime)
             #if DEBUG
-                os_log(.info, "Attachment migration completed in %{public}.2f seconds", duration)
+                os_log(
+                    .info,
+                    "Attachment migration completed in %{public}.2f seconds",
+                    duration
+                )
             #endif
 
         } catch {
             #if DEBUG
-                os_log(.error, "Attachment migration failed: %{public}@", String(describing: error))
+                os_log(
+                    .error,
+                    "Attachment migration failed: %{private}@",
+                    String(describing: error)
+                )
             #endif
             throw AttachmentError.migrationFailed(error)
         }

--- a/Modules/HistoryStore/Sources/HardenedKeychainManager.swift
+++ b/Modules/HistoryStore/Sources/HardenedKeychainManager.swift
@@ -322,8 +322,13 @@ public class HardenedKeychainManager {
         let timestamp = ISO8601DateFormatter().string(from: Date())
 
         #if DEBUG
-            os_log(.debug, "\u{1F512} Security Event [%{public}@]: %{public}@ - %{public}@",
-                   timestamp, event.rawValue, details)
+            os_log(
+                .debug,
+                "\u{1F512} Security Event [%{private}@]: %{public}@ - %{private}@",
+                timestamp,
+                event.rawValue,
+                details
+            )
         #endif
 
         // In production, you might want to log to a secure audit trail

--- a/Modules/PriceCapture/Sources/PrivacyAwareOCRManager.swift
+++ b/Modules/PriceCapture/Sources/PrivacyAwareOCRManager.swift
@@ -357,8 +357,13 @@ public class PrivacyAwareOCRManager: NSObject {
         let timestamp = ISO8601DateFormatter().string(from: Date())
 
         #if DEBUG
-            os_log(.debug, "\u{1F512} Privacy Event [%{public}@]: %{public}@ - %{public}@",
-                   timestamp, event.rawValue, details)
+            os_log(
+                .debug,
+                "\u{1F512} Privacy Event [%{private}@]: %{public}@ - %{private}@",
+                timestamp,
+                event.rawValue,
+                details
+            )
         #endif
 
         // In production, log to privacy audit trail
@@ -471,8 +476,12 @@ public class PrivacySettings {
 
     private func logPrivacyEvent(_ event: PrivacyEvent, details: String) {
         #if DEBUG
-            os_log(.debug, "\u{1F512} Privacy Setting: %{public}@ - %{public}@",
-                   event.rawValue, details)
+            os_log(
+                .debug,
+                "\u{1F512} Privacy Setting: %{public}@ - %{private}@",
+                event.rawValue,
+                details
+            )
         #endif
     }
 }

--- a/Modules/TimeBudget/Sources/TimeBudgetPlanner.swift
+++ b/Modules/TimeBudget/Sources/TimeBudgetPlanner.swift
@@ -295,8 +295,13 @@ public class TimeBudgetPlanner: BaseViewModel {
         let timestamp = ISO8601DateFormatter().string(from: Date())
 
         #if DEBUG
-            os_log(.debug, "\u{1F4B0} Budget Event [%{public}@]: %{public}@ - %{public}@",
-                   timestamp, event.rawValue, details)
+            os_log(
+                .debug,
+                "\u{1F4B0} Budget Event [%{private}@]: %{public}@ - %{private}@",
+                timestamp,
+                event.rawValue,
+                details
+            )
         #endif
 
         // In production, log to analytics or audit trail

--- a/Modules/TransactionLogger/Sources/ShortcutTemplate.swift
+++ b/Modules/TransactionLogger/Sources/ShortcutTemplate.swift
@@ -175,7 +175,11 @@ public class ShortcutTemplate {
             return shortcutURL
         } catch {
             #if DEBUG
-                os_log(.error, "Failed to export shortcut template: %{public}@", String(describing: error))
+                os_log(
+                    .error,
+                    "Failed to export shortcut template: %{private}@",
+                    String(describing: error)
+                )
             #endif
             return nil
         }

--- a/Modules/TransactionLogger/Sources/TransactionLogger.swift
+++ b/Modules/TransactionLogger/Sources/TransactionLogger.swift
@@ -113,7 +113,11 @@ public class TransactionLogger: ObservableObject {
             try await notificationCenter.add(request)
         } catch {
             #if DEBUG
-                os_log(.error, "Failed to post notification: %{public}@", String(describing: error))
+                os_log(
+                    .error,
+                    "Failed to post notification: %{private}@",
+                    String(describing: error)
+                )
             #endif
         }
     }
@@ -152,7 +156,11 @@ public class TransactionLogger: ObservableObject {
             try await notificationCenter.add(request)
         } catch {
             #if DEBUG
-                os_log(.error, "Failed to undo transaction: %{public}@", String(describing: error))
+                os_log(
+                    .error,
+                    "Failed to undo transaction: %{private}@",
+                    String(describing: error)
+                )
             #endif
         }
     }


### PR DESCRIPTION
## Summary
- secure os_log usage with explicit privacy modifiers
- introduce an `OSLog` category for the App Shell
- update debug logging across modules

## Testing
- `swift test` *(fails: no such module 'Combine')*

------
https://chatgpt.com/codex/tasks/task_e_688bde0bd294833092f2b0a95012304f