### PR TITLE
Add survey question data model

### DIFF
--- a/Assets/Questions/questions.json
+++ b/Assets/Questions/questions.json
@@ -1,0 +1,27 @@
+[
+  {
+    "id": "q1",
+    "text": "Do you enjoy using LifeMeter?",
+    "answerType": "bool"
+  },
+  {
+    "id": "q2",
+    "text": "How many purchases do you track weekly?",
+    "answerType": "int"
+  },
+  {
+    "id": "q3",
+    "text": "What is your average coffee price?",
+    "answerType": "double"
+  },
+  {
+    "id": "q4",
+    "text": "Preferred currency?",
+    "answerType": "string"
+  },
+  {
+    "id": "q5",
+    "text": "Would you recommend LifeMeter to friends?",
+    "answerType": "bool"
+  }
+]

--- a/Modules/LifeCore/Sources/Question.swift
+++ b/Modules/LifeCore/Sources/Question.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+public enum AnswerType: String, Codable {
+    case bool
+    case int
+    case double
+    case string
+}
+
+public struct Question: Codable, Identifiable {
+    public let id: String
+    public let text: String
+    public let answerType: AnswerType
+
+    public init(id: String, text: String, answerType: AnswerType) {
+        self.id = id
+        self.text = text
+        self.answerType = answerType
+    }
+}

--- a/Modules/LifeCore/Sources/QuestionBank.swift
+++ b/Modules/LifeCore/Sources/QuestionBank.swift
@@ -1,0 +1,29 @@
+import Combine
+import Foundation
+
+// MARK: - Question Bank
+
+public final class QuestionBank: ObservableObject {
+    public static let shared = QuestionBank()
+
+    @Published public private(set) var questions: [Question] = []
+
+    private var loaded = false
+
+    private init() {
+        load()
+    }
+
+    // MARK: - Loading
+
+    private func load() {
+        guard !loaded else { return }
+        loaded = true
+
+        if let url = Bundle.main.url(forResource: "questions", withExtension: "json", subdirectory: "Assets/Questions"),
+           let data = try? Data(contentsOf: url),
+           let decoded = try? JSONDecoder().decode([Question].self, from: data) {
+            questions = decoded
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `Question` model and `AnswerType` enum
- implement `QuestionBank` for loading survey questions
- seed sample questions JSON in `Assets/Questions`

## Testing
- `swift test -c release` *(fails: no such module 'Combine')*

------
https://chatgpt.com/codex/tasks/task_e_688bfc1dd4648330b507c97d87444710