### PR TITLE
Implement data-driven onboarding flow

### DIFF
--- a/Modules/AppShell/Sources/AnswerField.swift
+++ b/Modules/AppShell/Sources/AnswerField.swift
@@ -1,0 +1,25 @@
+import SwiftUI
+import LifeCore
+
+@available(iOS 15.0, *)
+struct AnswerField: View {
+    let question: Question
+    @Binding var textAnswer: String
+    @Binding var boolAnswer: Bool
+
+    var body: some View {
+        switch question.answerType {
+        case .bool:
+            Toggle(question.text, isOn: $boolAnswer)
+                .toggleStyle(SwitchToggleStyle())
+        case .int:
+            TextField(question.text, text: $textAnswer)
+                .keyboardType(.numberPad)
+        case .double:
+            TextField(question.text, text: $textAnswer)
+                .keyboardType(.decimalPad)
+        case .string:
+            TextField(question.text, text: $textAnswer)
+        }
+    }
+}

--- a/Modules/AppShell/Sources/OnboardingFlowView.swift
+++ b/Modules/AppShell/Sources/OnboardingFlowView.swift
@@ -1,0 +1,50 @@
+import SwiftUI
+import LifeCore
+
+@available(iOS 15.0, *)
+public struct OnboardingFlowView: View {
+    @StateObject private var viewModel = OnboardingFlowViewModel()
+    @State private var textAnswers: [String: String] = [:]
+    @State private var boolAnswers: [String: Bool] = [:]
+
+    public init() {}
+
+    public var body: some View {
+        let questions = viewModel.questionBank.questions
+        TabView(selection: $viewModel.currentIndex) {
+            ForEach(Array(questions.enumerated()), id: \.element.id) { index, question in
+                VStack(spacing: 24) {
+                    AnswerField(
+                        question: question,
+                        textAnswer: Binding(
+                            get: { textAnswers[question.id] ?? "" },
+                            set: { textAnswers[question.id] = $0 }
+                        ),
+                        boolAnswer: Binding(
+                            get: { boolAnswers[question.id] ?? false },
+                            set: { boolAnswers[question.id] = $0 }
+                        )
+                    )
+                    Button(index + 1 == questions.count ? "Finish" : "Next") {
+                        let value: AnyCodable
+                        switch question.answerType {
+                        case .bool:
+                            value = AnyCodable(boolAnswers[question.id] ?? false)
+                        case .int:
+                            value = AnyCodable(Int(textAnswers[question.id] ?? "") ?? 0)
+                        case .double:
+                            value = AnyCodable(Double(textAnswers[question.id] ?? "") ?? 0)
+                        case .string:
+                            value = AnyCodable(textAnswers[question.id] ?? "")
+                        }
+                        viewModel.answer(question: question, with: value)
+                    }
+                    .buttonStyle(.borderedProminent)
+                }
+                .padding()
+                .tag(index)
+            }
+        }
+        .tabViewStyle(PageTabViewStyle())
+    }
+}

--- a/Modules/AppShell/Sources/OnboardingFlowViewModel.swift
+++ b/Modules/AppShell/Sources/OnboardingFlowViewModel.swift
@@ -1,0 +1,16 @@
+import SwiftUI
+import LifeCore
+
+@available(iOS 15.0, *)
+public final class OnboardingFlowViewModel: ObservableObject {
+    @Published public var currentIndex: Int = 0
+    @ObservedObject public var questionBank = QuestionBank.shared
+    private let lifeViewModel = LifeViewModel()
+
+    public init() {}
+
+    public func answer(question: Question, with value: AnyCodable) {
+        lifeViewModel.answer(question: question.id, with: value)
+        currentIndex += 1
+    }
+}


### PR DESCRIPTION
## Summary
- add an `OnboardingFlowViewModel` to manage onboarding questions
- create a generic `AnswerField` component
- use `ForEach(questionBank.questions)` in new `OnboardingFlowView`

## Testing
- `swift test` *(fails: no such module 'Combine')*

------
https://chatgpt.com/codex/tasks/task_e_688c78431e6083309af684ac3782374e