### PR TITLE
Remove fixed 365‑day math

### DIFF
--- a/Modules/LifeCore/Tests/DateMathTests.swift
+++ b/Modules/LifeCore/Tests/DateMathTests.swift
@@ -1,0 +1,11 @@
+import XCTest
+
+final class DateMathTests: XCTestCase {
+    func testLeapYearBoundary() {
+        let calendar = Calendar.iso8601
+        let birth = calendar.date(from: DateComponents(year: 1992, month: 2, day: 29))!
+        let target = calendar.date(from: DateComponents(year: 2025, month: 3, day: 1))!
+        let age = calendar.dateComponents([.year], from: birth, to: target).year
+        XCTAssertEqual(age, 33)
+    }
+}

--- a/Modules/TimeBudget/Sources/TimeBudgetPlanner.swift
+++ b/Modules/TimeBudget/Sources/TimeBudgetPlanner.swift
@@ -598,7 +598,10 @@ public class TimeBudgetCalculator {
         case .daily: return 24 * 60 * 60 // 1 day
         case .weekly: return 7 * 24 * 60 * 60 // 1 week
         case .monthly: return 30 * 24 * 60 * 60 // ~1 month
-        case .yearly: return 365 * 24 * 60 * 60 // ~1 year
+        case .yearly:
+            let now = Date()
+            let endDate = Calendar.current.date(byAdding: .year, value: 1, to: now) ?? now
+            return endDate.timeIntervalSince(now)
         }
     }
 }


### PR DESCRIPTION
## Summary
- replace hard‑coded year duration with `Calendar` math
- add leap year date math test

## Testing
- `swift test` *(fails: no such module 'Combine')*

------
https://chatgpt.com/codex/tasks/task_e_688c7ae5f87c8330801a7d29aeb8801a